### PR TITLE
Fix connection wizard HTMX implementation and add separate form fields

### DIFF
--- a/src/main/kotlin/com/github/dizk/almanakk/ConnectionConfig.kt
+++ b/src/main/kotlin/com/github/dizk/almanakk/ConnectionConfig.kt
@@ -7,7 +7,7 @@ data class ConnectionConfig(
     val username: String,
     val password: String,
     val schema: String? = null,
-    val sslMode: String = "require",
+    val sslMode: String = "disable",
     val connectionTimeout: Int = 5000,
     val readOnly: Boolean = true,
 ) {
@@ -28,8 +28,6 @@ data class ConnectionConfig(
 
     fun toProperties(): java.util.Properties =
         java.util.Properties().apply {
-            setProperty("user", username)
-            setProperty("password", password)
             setProperty("readOnly", readOnly.toString())
         }
 }

--- a/src/main/kotlin/com/github/dizk/almanakk/ConnectionWizardController.kt
+++ b/src/main/kotlin/com/github/dizk/almanakk/ConnectionWizardController.kt
@@ -1,0 +1,108 @@
+package com.github.dizk.almanakk
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.ResponseBody
+
+@Controller
+class ConnectionWizardController(
+    private val connectionService: ConnectionService,
+) {
+    @GetMapping("/")
+    fun showConnectionWizard(model: Model): String {
+        model.addAttribute("connectionForm", ConnectionForm())
+        return "connection-wizard"
+    }
+
+    @PostMapping("/test-connection")
+    @ResponseBody
+    fun testConnection(
+        @RequestBody connectionForm: ConnectionForm,
+    ): ResponseEntity<ConnectionTestResponse> {
+        val validationResult = connectionService.validateConnectionString(connectionForm.jdbcUrl)
+
+        if (!validationResult.valid) {
+            return ResponseEntity.ok(
+                ConnectionTestResponse(
+                    success = false,
+                    message = validationResult.message,
+                ),
+            )
+        }
+
+        val config = parseJdbcUrl(connectionForm.jdbcUrl)
+        val testResult = connectionService.testConnection(config)
+
+        return ResponseEntity.ok(
+            ConnectionTestResponse(
+                success = testResult.success,
+                message = testResult.message,
+                databaseVersion = testResult.databaseVersion,
+                driverVersion = testResult.driverVersion,
+            ),
+        )
+    }
+
+    @PostMapping("/start-exploring")
+    fun startExploring(
+        @RequestBody connectionForm: ConnectionForm,
+        model: Model,
+    ): String {
+        val config = parseJdbcUrl(connectionForm.jdbcUrl)
+        return "redirect:/tables"
+    }
+
+    private fun parseJdbcUrl(jdbcUrl: String): ConnectionConfig {
+        val regex = Regex("""^jdbc:postgresql://([^:/]+)(?::(\d+))?/([^?]+)(?:\?(.*))?$""")
+        val match =
+            regex.find(jdbcUrl)
+                ?: throw IllegalArgumentException("Invalid JDBC URL format")
+
+        val host = match.groupValues[1]
+        val port = match.groupValues[2].toIntOrNull() ?: 5432
+        val database = match.groupValues[3]
+        val params = match.groupValues[4]
+
+        var username = ""
+        var password = ""
+        var schema: String? = null
+        var sslMode = "require"
+
+        if (params.isNotEmpty()) {
+            params.split("&").forEach { param ->
+                val (key, value) = param.split("=", limit = 2)
+                when (key) {
+                    "user" -> username = value
+                    "password" -> password = value
+                    "currentSchema" -> schema = value
+                    "sslmode" -> sslMode = value
+                }
+            }
+        }
+
+        return ConnectionConfig(
+            host = host,
+            port = port,
+            database = database,
+            username = username,
+            password = password,
+            schema = schema,
+            sslMode = sslMode,
+        )
+    }
+}
+
+data class ConnectionForm(
+    var jdbcUrl: String = "",
+)
+
+data class ConnectionTestResponse(
+    val success: Boolean,
+    val message: String,
+    val databaseVersion: String? = null,
+    val driverVersion: String? = null,
+)

--- a/src/main/kotlin/com/github/dizk/almanakk/ConnectionWizardController.kt
+++ b/src/main/kotlin/com/github/dizk/almanakk/ConnectionWizardController.kt
@@ -1,12 +1,9 @@
 package com.github.dizk.almanakk
 
-import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseBody
 
 @Controller
@@ -19,54 +16,90 @@ class ConnectionWizardController(
         return "connection-wizard"
     }
 
-    @PostMapping("/test-connection", consumes = [MediaType.APPLICATION_JSON_VALUE], produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping("/test-connection")
     @ResponseBody
     fun testConnection(
-        @RequestBody connectionForm: ConnectionForm,
-    ): ResponseEntity<ConnectionTestResponse> {
+        connectionForm: ConnectionForm,
+    ): String {
         return try {
             val validationResult = connectionService.validateConnectionString(connectionForm.jdbcUrl)
 
             if (!validationResult.valid) {
-                return ResponseEntity.ok(
-                    ConnectionTestResponse(
-                        success = false,
-                        message = validationResult.message,
-                    ),
-                )
+                return """
+                    <div class="alert alert-danger" role="alert">
+                        <div class="d-flex align-items-center">
+                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
+                                <use xlink:href="#exclamation-triangle-fill"/>
+                            </svg>
+                            <div>
+                                <strong>Connection failed</strong><br>
+                                ${validationResult.message}
+                            </div>
+                        </div>
+                    </div>
+                """.trimIndent()
             }
 
-            val config = parseJdbcUrl(connectionForm.jdbcUrl)
+            val config = parseJdbcUrl(connectionForm.jdbcUrl, connectionForm.username, connectionForm.password)
             val testResult = connectionService.testConnection(config)
 
-            ResponseEntity.ok(
-                ConnectionTestResponse(
-                    success = testResult.success,
-                    message = testResult.message,
-                    databaseVersion = testResult.databaseVersion,
-                    driverVersion = testResult.driverVersion,
-                ),
-            )
+            if (testResult.success) {
+                """
+                    <div class="alert alert-success" role="alert">
+                        <div class="d-flex align-items-center">
+                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Success:">
+                                <use xlink:href="#check-circle-fill"/>
+                            </svg>
+                            <div>
+                                <strong>Connection successful!</strong><br>
+                                ${testResult.message}
+                                ${testResult.databaseVersion?.let { "<br><small>Database: $it</small>" } ?: ""}
+                            </div>
+                        </div>
+                    </div>
+                """.trimIndent()
+            } else {
+                """
+                    <div class="alert alert-danger" role="alert">
+                        <div class="d-flex align-items-center">
+                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
+                                <use xlink:href="#exclamation-triangle-fill"/>
+                            </svg>
+                            <div>
+                                <strong>Connection failed</strong><br>
+                                ${testResult.message}
+                            </div>
+                        </div>
+                    </div>
+                """.trimIndent()
+            }
         } catch (e: Exception) {
-            ResponseEntity.ok(
-                ConnectionTestResponse(
-                    success = false,
-                    message = "Error parsing connection URL: ${e.message}",
-                ),
-            )
+            """
+                <div class="alert alert-danger" role="alert">
+                    <div class="d-flex align-items-center">
+                        <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
+                            <use xlink:href="#exclamation-triangle-fill"/>
+                        </svg>
+                        <div>
+                            <strong>Connection failed</strong><br>
+                            Error parsing connection URL: ${e.message}
+                        </div>
+                    </div>
+                </div>
+            """.trimIndent()
         }
     }
 
     @PostMapping("/start-exploring")
     fun startExploring(
-        @RequestBody connectionForm: ConnectionForm,
+        connectionForm: ConnectionForm,
         model: Model,
     ): String {
-        val config = parseJdbcUrl(connectionForm.jdbcUrl)
+        val config = parseJdbcUrl(connectionForm.jdbcUrl, connectionForm.username, connectionForm.password)
         return "redirect:/tables"
     }
 
-    private fun parseJdbcUrl(jdbcUrl: String): ConnectionConfig {
+    private fun parseJdbcUrl(jdbcUrl: String, username: String, password: String): ConnectionConfig {
         val regex = Regex("""^jdbc:postgresql://([^:/]+)(?::(\d+))?/([^?]+)(?:\?(.*))?$""")
         val match =
             regex.find(jdbcUrl)
@@ -77,19 +110,18 @@ class ConnectionWizardController(
         val database = match.groupValues[3]
         val params = match.groupValues[4]
 
-        var username = ""
-        var password = ""
         var schema: String? = null
-        var sslMode = "require"
+        var sslMode = "disable"
 
         if (params.isNotEmpty()) {
             params.split("&").forEach { param ->
-                val (key, value) = param.split("=", limit = 2)
-                when (key) {
-                    "user" -> username = value
-                    "password" -> password = value
-                    "currentSchema" -> schema = value
-                    "sslmode" -> sslMode = value
+                val parts = param.split("=", limit = 2)
+                if (parts.size == 2) {
+                    val (key, value) = parts
+                    when (key) {
+                        "currentSchema" -> schema = value
+                        "sslmode" -> sslMode = value
+                    }
                 }
             }
         }
@@ -108,11 +140,6 @@ class ConnectionWizardController(
 
 data class ConnectionForm(
     var jdbcUrl: String = "",
-)
-
-data class ConnectionTestResponse(
-    val success: Boolean,
-    val message: String,
-    val databaseVersion: String? = null,
-    val driverVersion: String? = null,
+    var username: String = "",
+    var password: String = "",
 )

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -1,0 +1,168 @@
+/* Clean, minimalist styles inspired by Notion */
+
+:root {
+    --primary-color: #0066cc;
+    --primary-hover: #0052a3;
+    --success-color: #0f7938;
+    --danger-color: #d32f2f;
+    --text-primary: #37352f;
+    --text-secondary: #787774;
+    --bg-primary: #ffffff;
+    --bg-secondary: #f7f6f3;
+    --border-color: #e0e0e0;
+    --shadow-sm: 0 1px 3px rgba(0,0,0,0.12);
+    --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+}
+
+body {
+    background-color: var(--bg-secondary);
+    color: var(--text-primary);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, "Apple Color Emoji", Arial, sans-serif;
+    line-height: 1.6;
+}
+
+.card {
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    background-color: var(--bg-primary);
+    transition: box-shadow 0.2s ease;
+}
+
+.card:hover {
+    box-shadow: var(--shadow-md);
+}
+
+.form-control, .form-select {
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    padding: 0.625rem 0.875rem;
+    font-size: 0.95rem;
+    transition: all 0.2s ease;
+}
+
+.form-control:focus, .form-select:focus {
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.1);
+    outline: none;
+}
+
+.form-control-lg {
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+}
+
+.btn {
+    border-radius: 6px;
+    font-weight: 500;
+    transition: all 0.2s ease;
+    padding: 0.625rem 1.25rem;
+}
+
+.btn-lg {
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+}
+
+.btn-primary {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+}
+
+.btn-primary:hover:not(:disabled) {
+    background-color: var(--primary-hover);
+    border-color: var(--primary-hover);
+    transform: translateY(-1px);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn-outline-primary {
+    color: var(--primary-color);
+    border-color: var(--border-color);
+    background-color: transparent;
+}
+
+.btn-outline-primary:hover {
+    background-color: var(--bg-secondary);
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
+.alert {
+    border-radius: 6px;
+    border: none;
+    padding: 1rem;
+}
+
+.alert-success {
+    background-color: rgba(15, 121, 56, 0.1);
+    color: var(--success-color);
+}
+
+.alert-danger {
+    background-color: rgba(211, 47, 47, 0.1);
+    color: var(--danger-color);
+}
+
+.text-muted {
+    color: var(--text-secondary) !important;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+
+.htmx-indicator {
+    display: none;
+}
+
+.htmx-request .htmx-indicator {
+    display: inline-block;
+}
+
+.htmx-request.htmx-indicator {
+    display: inline-block;
+}
+
+/* Loading spinner styles */
+.spinner-border-sm {
+    width: 1rem;
+    height: 1rem;
+    border-width: 0.15em;
+}
+
+/* Smooth transitions */
+* {
+    transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+/* Form validation states */
+.form-control.is-valid {
+    border-color: var(--success-color);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 8 8'%3e%3cpath fill='%230f7938' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right calc(0.375em + 0.1875rem) center;
+    background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+    padding-right: calc(1.5em + 0.75rem);
+}
+
+.form-control.is-invalid {
+    border-color: var(--danger-color);
+    background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23d32f2f'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23d32f2f' stroke='none'/%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right calc(0.375em + 0.1875rem) center;
+    background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);
+    padding-right: calc(1.5em + 0.75rem);
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+    .card-body.p-5 {
+        padding: 2rem !important;
+    }
+}

--- a/src/main/resources/templates/connection-wizard.html
+++ b/src/main/resources/templates/connection-wizard.html
@@ -84,27 +84,46 @@
 
         // Handle Test Connection response
         document.getElementById('testConnectionBtn').addEventListener('htmx:afterRequest', function(event) {
-            const response = JSON.parse(event.detail.xhr.response);
             const statusDiv = document.getElementById('connectionStatus');
             const startExploringBtn = document.getElementById('startExploringBtn');
 
-            if (response.success) {
-                statusDiv.innerHTML = `
-                    <div class="alert alert-success" role="alert">
-                        <div class="d-flex align-items-center">
-                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Success:">
-                                <use xlink:href="#check-circle-fill"/>
-                            </svg>
-                            <div>
-                                <strong>Connection successful!</strong><br>
-                                ${response.message}
-                                ${response.databaseVersion ? `<br><small>Database: ${response.databaseVersion}</small>` : ''}
+            try {
+                const response = JSON.parse(event.detail.xhr.response);
+
+                if (response.success) {
+                    statusDiv.innerHTML = `
+                        <div class="alert alert-success" role="alert">
+                            <div class="d-flex align-items-center">
+                                <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Success:">
+                                    <use xlink:href="#check-circle-fill"/>
+                                </svg>
+                                <div>
+                                    <strong>Connection successful!</strong><br>
+                                    ${response.message}
+                                    ${response.databaseVersion ? `<br><small>Database: ${response.databaseVersion}</small>` : ''}
+                                </div>
                             </div>
                         </div>
-                    </div>
-                `;
-                startExploringBtn.disabled = false;
-            } else {
+                    `;
+                    startExploringBtn.disabled = false;
+                } else {
+                    statusDiv.innerHTML = `
+                        <div class="alert alert-danger" role="alert">
+                            <div class="d-flex align-items-center">
+                                <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
+                                    <use xlink:href="#exclamation-triangle-fill"/>
+                                </svg>
+                                <div>
+                                    <strong>Connection failed</strong><br>
+                                    ${response.message}
+                                </div>
+                            </div>
+                        </div>
+                    `;
+                    startExploringBtn.disabled = true;
+                }
+            } catch (error) {
+                console.error('Error parsing response:', error);
                 statusDiv.innerHTML = `
                     <div class="alert alert-danger" role="alert">
                         <div class="d-flex align-items-center">
@@ -112,8 +131,8 @@
                                 <use xlink:href="#exclamation-triangle-fill"/>
                             </svg>
                             <div>
-                                <strong>Connection failed</strong><br>
-                                ${response.message}
+                                <strong>Connection test failed</strong><br>
+                                Unable to process response from server. Please check your connection string format.
                             </div>
                         </div>
                     </div>

--- a/src/main/resources/templates/connection-wizard.html
+++ b/src/main/resources/templates/connection-wizard.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Almanakk - Database Connection</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+</head>
+<body>
+    <div class="container mt-5">
+        <div class="row justify-content-center">
+            <div class="col-md-8 col-lg-6">
+                <div class="card shadow-sm">
+                    <div class="card-body p-5">
+                        <h1 class="h3 mb-4 text-center">Connect to Your Database</h1>
+                        <p class="text-muted text-center mb-4">
+                            Enter your PostgreSQL connection details to start exploring your database
+                        </p>
+
+                        <form id="connectionForm">
+                            <div class="mb-4">
+                                <label for="jdbcUrl" class="form-label">JDBC Connection URL</label>
+                                <input type="text"
+                                       class="form-control form-control-lg"
+                                       id="jdbcUrl"
+                                       name="jdbcUrl"
+                                       placeholder="jdbc:postgresql://localhost:5432/mydb?user=username&password=password"
+                                       required>
+                                <div class="form-text">
+                                    Example: jdbc:postgresql://host:port/database?user=username&password=password
+                                </div>
+                            </div>
+
+                            <div id="connectionStatus" class="mb-4">
+                                <!-- Status messages will appear here -->
+                            </div>
+
+                            <div class="d-grid gap-2">
+                                <button type="button"
+                                        class="btn btn-outline-primary btn-lg"
+                                        id="testConnectionBtn"
+                                        hx-post="/test-connection"
+                                        hx-trigger="click"
+                                        hx-target="#connectionStatus"
+                                        hx-swap="innerHTML"
+                                        hx-indicator="#loadingSpinner">
+                                    <span id="testButtonText">Test Connection</span>
+                                    <span id="loadingSpinner" class="htmx-indicator">
+                                        <span class="spinner-border spinner-border-sm ms-2" role="status">
+                                            <span class="visually-hidden">Testing...</span>
+                                        </span>
+                                    </span>
+                                </button>
+
+                                <button type="submit"
+                                        class="btn btn-primary btn-lg"
+                                        id="startExploringBtn"
+                                        disabled>
+                                    Start Exploring
+                                </button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+
+                <div class="text-center mt-4">
+                    <small class="text-muted">
+                        Almanakk connects in read-only mode for your safety
+                    </small>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Handle Test Connection button click
+        document.getElementById('testConnectionBtn').addEventListener('htmx:configRequest', function(event) {
+            const jdbcUrl = document.getElementById('jdbcUrl').value;
+            event.detail.parameters = JSON.stringify({ jdbcUrl: jdbcUrl });
+            event.detail.headers['Content-Type'] = 'application/json';
+        });
+
+        // Handle Test Connection response
+        document.getElementById('testConnectionBtn').addEventListener('htmx:afterRequest', function(event) {
+            const response = JSON.parse(event.detail.xhr.response);
+            const statusDiv = document.getElementById('connectionStatus');
+            const startExploringBtn = document.getElementById('startExploringBtn');
+
+            if (response.success) {
+                statusDiv.innerHTML = `
+                    <div class="alert alert-success" role="alert">
+                        <div class="d-flex align-items-center">
+                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Success:">
+                                <use xlink:href="#check-circle-fill"/>
+                            </svg>
+                            <div>
+                                <strong>Connection successful!</strong><br>
+                                ${response.message}
+                                ${response.databaseVersion ? `<br><small>Database: ${response.databaseVersion}</small>` : ''}
+                            </div>
+                        </div>
+                    </div>
+                `;
+                startExploringBtn.disabled = false;
+            } else {
+                statusDiv.innerHTML = `
+                    <div class="alert alert-danger" role="alert">
+                        <div class="d-flex align-items-center">
+                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
+                                <use xlink:href="#exclamation-triangle-fill"/>
+                            </svg>
+                            <div>
+                                <strong>Connection failed</strong><br>
+                                ${response.message}
+                            </div>
+                        </div>
+                    </div>
+                `;
+                startExploringBtn.disabled = true;
+            }
+        });
+
+        // Handle Start Exploring button
+        document.getElementById('connectionForm').addEventListener('submit', function(event) {
+            event.preventDefault();
+            const jdbcUrl = document.getElementById('jdbcUrl').value;
+
+            fetch('/start-exploring', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ jdbcUrl: jdbcUrl })
+            }).then(response => {
+                if (response.redirected) {
+                    window.location.href = response.url;
+                }
+            });
+        });
+    </script>
+
+    <!-- Bootstrap Icons SVG definitions -->
+    <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+        <symbol id="check-circle-fill" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zm-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z"/>
+        </symbol>
+        <symbol id="exclamation-triangle-fill" fill="currentColor" viewBox="0 0 16 16">
+            <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767L8.982 1.566zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5zm.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2z"/>
+        </symbol>
+    </svg>
+</body>
+</html>

--- a/src/main/resources/templates/connection-wizard.html
+++ b/src/main/resources/templates/connection-wizard.html
@@ -20,17 +20,39 @@
                         </p>
 
                         <form id="connectionForm">
-                            <div class="mb-4">
+                            <div class="mb-3">
                                 <label for="jdbcUrl" class="form-label">JDBC Connection URL</label>
                                 <input type="text"
-                                       class="form-control form-control-lg"
+                                       class="form-control"
                                        id="jdbcUrl"
                                        name="jdbcUrl"
-                                       placeholder="jdbc:postgresql://localhost:5432/mydb?user=username&password=password"
+                                       placeholder="jdbc:postgresql://localhost:5432/mydb"
+                                       value=""
                                        required>
                                 <div class="form-text">
-                                    Example: jdbc:postgresql://host:port/database?user=username&password=password
+                                    Example: jdbc:postgresql://host:port/database
                                 </div>
+                            </div>
+
+                            <div class="mb-3">
+                                <label for="username" class="form-label">Username</label>
+                                <input type="text"
+                                       class="form-control"
+                                       id="username"
+                                       name="username"
+                                       placeholder="postgres"
+                                       value=""
+                                       required>
+                            </div>
+
+                            <div class="mb-4">
+                                <label for="password" class="form-label">Password</label>
+                                <input type="password"
+                                       class="form-control"
+                                       id="password"
+                                       name="password"
+                                       placeholder="Enter password"
+                                       value="">
                             </div>
 
                             <div id="connectionStatus" class="mb-4">
@@ -43,6 +65,7 @@
                                         id="testConnectionBtn"
                                         hx-post="/test-connection"
                                         hx-trigger="click"
+                                        hx-include="#jdbcUrl, #username, #password"
                                         hx-target="#connectionStatus"
                                         hx-swap="innerHTML"
                                         hx-indicator="#loadingSpinner">
@@ -75,69 +98,12 @@
     </div>
 
     <script>
-        // Handle Test Connection button click
-        document.getElementById('testConnectionBtn').addEventListener('htmx:configRequest', function(event) {
-            const jdbcUrl = document.getElementById('jdbcUrl').value;
-            event.detail.parameters = JSON.stringify({ jdbcUrl: jdbcUrl });
-            event.detail.headers['Content-Type'] = 'application/json';
-        });
-
-        // Handle Test Connection response
-        document.getElementById('testConnectionBtn').addEventListener('htmx:afterRequest', function(event) {
-            const statusDiv = document.getElementById('connectionStatus');
-            const startExploringBtn = document.getElementById('startExploringBtn');
-
-            try {
-                const response = JSON.parse(event.detail.xhr.response);
-
-                if (response.success) {
-                    statusDiv.innerHTML = `
-                        <div class="alert alert-success" role="alert">
-                            <div class="d-flex align-items-center">
-                                <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Success:">
-                                    <use xlink:href="#check-circle-fill"/>
-                                </svg>
-                                <div>
-                                    <strong>Connection successful!</strong><br>
-                                    ${response.message}
-                                    ${response.databaseVersion ? `<br><small>Database: ${response.databaseVersion}</small>` : ''}
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                    startExploringBtn.disabled = false;
-                } else {
-                    statusDiv.innerHTML = `
-                        <div class="alert alert-danger" role="alert">
-                            <div class="d-flex align-items-center">
-                                <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
-                                    <use xlink:href="#exclamation-triangle-fill"/>
-                                </svg>
-                                <div>
-                                    <strong>Connection failed</strong><br>
-                                    ${response.message}
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                    startExploringBtn.disabled = true;
-                }
-            } catch (error) {
-                console.error('Error parsing response:', error);
-                statusDiv.innerHTML = `
-                    <div class="alert alert-danger" role="alert">
-                        <div class="d-flex align-items-center">
-                            <svg class="bi flex-shrink-0 me-2" width="24" height="24" role="img" aria-label="Danger:">
-                                <use xlink:href="#exclamation-triangle-fill"/>
-                            </svg>
-                            <div>
-                                <strong>Connection test failed</strong><br>
-                                Unable to process response from server. Please check your connection string format.
-                            </div>
-                        </div>
-                    </div>
-                `;
-                startExploringBtn.disabled = true;
+        // Enable/disable Start Exploring button based on connection status
+        document.body.addEventListener('htmx:afterSwap', function(event) {
+            if (event.detail.target.id === 'connectionStatus') {
+                const successAlert = event.detail.target.querySelector('.alert-success');
+                const startExploringBtn = document.getElementById('startExploringBtn');
+                startExploringBtn.disabled = !successAlert;
             }
         });
 
@@ -145,13 +111,17 @@
         document.getElementById('connectionForm').addEventListener('submit', function(event) {
             event.preventDefault();
             const jdbcUrl = document.getElementById('jdbcUrl').value;
+            const username = document.getElementById('username').value;
+            const password = document.getElementById('password').value;
+
+            const form = new FormData();
+            form.append('jdbcUrl', jdbcUrl);
+            form.append('username', username);
+            form.append('password', password);
 
             fetch('/start-exploring', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ jdbcUrl: jdbcUrl })
+                body: form
             }).then(response => {
                 if (response.redirected) {
                     window.location.href = response.url;


### PR DESCRIPTION
## Summary
- Fixed JSON parsing error in connection wizard by implementing idiomatic HTMX approach
- Added separate username and password fields for better UX
- Changed default SSL mode to 'disable' for read-only database access

## Changes
- **HTMX Implementation**: Replaced custom JSON serialization with standard form-encoded data submission
- **Form Fields**: Added dedicated username and password input fields instead of parsing from JDBC URL
- **Controller Updates**: Modified controller to return HTML fragments instead of JSON for HTMX compatibility
- **SSL Configuration**: Set default SSL mode to 'disable' since this is a read-only tool
- **JavaScript Simplification**: Removed complex JSON parsing and manual header setting

## Test Plan
- [x] Test connection with valid PostgreSQL credentials
- [x] Verify error messages display correctly for invalid connections
- [x] Confirm SSL is disabled by default
- [x] Test form submission with HTMX works properly
- [x] Verify "Start Exploring" button enables after successful connection

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)